### PR TITLE
Changed "include" to "are" to be clear that the list of evaluated relations is exhaustive

### DIFF
--- a/evaluation/README.md
+++ b/evaluation/README.md
@@ -24,8 +24,8 @@ We will report P/R/F1 for the positive and negative classes. The official score 
 
 2. Subtask 2: Sequence labeling
 
-We will report P/R/F1 for each evaluated class, as well as macro- and micro-averaged F1 for the evaluated classes. The official score will be based on  the macro-averaged F1 of the evaluated classes. Evaluated classes include: Term, Alias-Term, Referential-Term, Definition, Referential-Definition, and Qualifier.
+We will report P/R/F1 for each evaluated class, as well as macro- and micro-averaged F1 for the evaluated classes. The official score will be based on  the macro-averaged F1 of the evaluated classes. Evaluated classes are Term, Alias-Term, Referential-Term, Definition, Referential-Definition, and Qualifier.
 
 3. Subtask 3: Relation extraction
 
-We will report P/R/F1 for each evaluated relation, as well as macro- and micro-averaged F1 for the evaluated relations. The official score will be based on  the macro-averaged F1 of the evaluated relations. The evaluated relations include: Direct-defines, Indirect-defines, Refers-to, AKA, and Qualifies.
+We will report P/R/F1 for each evaluated relation, as well as macro- and micro-averaged F1 for the evaluated relations. The official score will be based on  the macro-averaged F1 of the evaluated relations. The evaluated relations are Direct-defines, Indirect-defines, Refers-to, AKA, and Qualifies.


### PR DESCRIPTION
I'm assuming that the list of evaluated relations is exhaustive, so changed `include` to `are` to be clear about it.