### PR TITLE
Fix some invalid BIO tags

### DIFF
--- a/data/deft_files/train/t1_biology_1_404.deft
+++ b/data/deft_files/train/t1_biology_1_404.deft
@@ -4147,7 +4147,7 @@ from	data/source_txt/train/t1_biology_1_404.txt	 23303	 23307	 O	 -1	 -1	 0
 or	data/source_txt/train/t1_biology_1_404.txt	 23308	 23310	 O	 -1	 -1	 0
 enter	data/source_txt/train/t1_biology_1_404.txt	 23311	 23316	 O	 -1	 -1	 0
 the	data/source_txt/train/t1_biology_1_404.txt	 23317	 23320	 B-Definition	 T233	 T234	 Direct-Defines
-skull	data/source_txt/train/t1_biology_1_404.txt	 23321	 23326	 Definition	 T233	 T234	 Direct-Defines
+skull	data/source_txt/train/t1_biology_1_404.txt	 23321	 23326	 I-Definition	 T233	 T234	 Direct-Defines
 (	data/source_txt/train/t1_biology_1_404.txt	 23327	 23328	 O	 -1	 -1	 0
 cranium	data/source_txt/train/t1_biology_1_404.txt	 23328	 23335	 B-Term	 T234	 0	 Direct-Defines
 )	data/source_txt/train/t1_biology_1_404.txt	 23335	 23336	 O	 -1	 -1	 0

--- a/data/deft_files/train/t1_biology_2_0.deft
+++ b/data/deft_files/train/t1_biology_2_0.deft
@@ -1804,7 +1804,7 @@ gravity	data/source_txt/train/t1_biology_2_0.txt	 12094	 12101	 O	 -1	 -1	 0
 litmus	data/source_txt/train/t1_biology_2_0.txt	 12119	 12125	 B-Alias-Term	 T219	 T220	 AKA
 or	data/source_txt/train/t1_biology_2_0.txt	 12126	 12128	 O	 -1	 -1	 0
 pH	data/source_txt/train/t1_biology_2_0.txt	 12129	 12131	 O	 -1	 -1	 0
-paper	data/source_txt/train/t1_biology_2_0.txt	 12132	 12137	I-Alias-Term-frag	 T219-frag	 T219	 fragment
+paper	data/source_txt/train/t1_biology_2_0.txt	 12132	 12137	B-Alias-Term-frag	 T219-frag	 T219	 fragment
 ,	data/source_txt/train/t1_biology_2_0.txt	 12137	 12138	 O	 -1	 -1	 0
 filter	data/source_txt/train/t1_biology_2_0.txt	 12139	 12145	 B-Definition	 T221	 T220	 Direct-Defines
 paper	data/source_txt/train/t1_biology_2_0.txt	 12146	 12151	 I-Definition	 T221	 T220	 Direct-Defines

--- a/data/deft_files/train/t1_biology_2_101.deft
+++ b/data/deft_files/train/t1_biology_2_101.deft
@@ -2669,7 +2669,7 @@ or	data/source_txt/train/t1_biology_2_101.txt	 15925	 15927	 I-Qualifier	 T245	 
 son	data/source_txt/train/t1_biology_2_101.txt	 15928	 15931	 I-Qualifier	 T245	 T244	 Supplements
 )	data/source_txt/train/t1_biology_2_101.txt	 15931	 15932	 O	 -1	 -1	 0
 ,	data/source_txt/train/t1_biology_2_101.txt	 15932	 15933	 O	 -1	 -1	 0
-generation	data/source_txt/train/t1_biology_2_101.txt	 15934	 15944	I-Alias-Term-frag	 T244-frag	 T244	 fragment
+generation	data/source_txt/train/t1_biology_2_101.txt	 15934	 15944	B-Alias-Term-frag	 T244-frag	 T244	 fragment
 .	data/source_txt/train/t1_biology_2_101.txt	 15944	 15945	 O	 -1	 -1	 0
 
 Once	data/source_txt/train/t1_biology_2_101.txt	 15952	 15956	 O	 -1	 -1	 0

--- a/data/deft_files/train/t3_physics_2_0.deft
+++ b/data/deft_files/train/t3_physics_2_0.deft
@@ -707,7 +707,7 @@ for	data/source_txt/train/t3_physics_2_0.txt	 4216	 4219	 I-Definition	 T30	 T31
 time	data/source_txt/train/t3_physics_2_0.txt	 4220	 4224	 I-Definition	 T30	 T31	 Direct-Defines
 ,	data/source_txt/train/t3_physics_2_0.txt	 4224	 4225	 O	 -1	 -1	 0
 the	data/source_txt/train/t3_physics_2_0.txt	 4226	 4229	 B-Term	 T31	 0	 AKA
-second(abbreviated	data/source_txt/train/t3_physics_2_0.txt	 4230	 4248	 Term	 T31	 0	 AKA
+second(abbreviated	data/source_txt/train/t3_physics_2_0.txt	 4230	 4248	 I-Term	 T31	 0	 AKA
 s	data/source_txt/train/t3_physics_2_0.txt	 4249	 4250	 B-Alias-Term	 T190	 T31	 AKA
 )	data/source_txt/train/t3_physics_2_0.txt	 4250	 4251	 O	 -1	 -1	 0
 ,	data/source_txt/train/t3_physics_2_0.txt	 4251	 4252	 O	 -1	 -1	 0

--- a/data/deft_files/train/t5_economic_0_202.deft
+++ b/data/deft_files/train/t5_economic_0_202.deft
@@ -4757,7 +4757,7 @@ as	data/source_txt/train/t5_economic_0_202.txt	 24515	 24517	 O	 -1	 -1	 0
 depreciating	data/source_txt/train/t5_economic_0_202.txt	 24518	 24530	 B-Term	 T109	 0	 Direct-Defines
 or	data/source_txt/train/t5_economic_0_202.txt	 24531	 24533	 O	 -1	 -1	 0
 “	data/source_txt/train/t5_economic_0_202.txt	 24534	 24535	 B-Alias-Term	 T110	 T109	 AKA
-weakening.”To	data/source_txt/train/t5_economic_0_202.txt	 24535	 24548	 Alias-Term	 T110	 T109	 AKA
+weakening.”To	data/source_txt/train/t5_economic_0_202.txt	 24535	 24548	 I-Alias-Term	 T110	 T109	 AKA
 illustrate	data/source_txt/train/t5_economic_0_202.txt	 24549	 24559	 O	 -1	 -1	 0
 the	data/source_txt/train/t5_economic_0_202.txt	 24560	 24563	 O	 -1	 -1	 0
 use	data/source_txt/train/t5_economic_0_202.txt	 24564	 24567	 O	 -1	 -1	 0


### PR DESCRIPTION
The exact labeling schema of the corpus is not obvious. Most tags follow a IOB2 schema, but for some the schema would be valid for IOB1 (standalone I-tags).

If you choose to fix these it is probably best to fix them in the source annotations, but I guessed it might still be helpful to have this diff.